### PR TITLE
Code completion and references for controllers

### DIFF
--- a/src/resharper-angularjs.sln
+++ b/src/resharper-angularjs.sln
@@ -5,6 +5,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "resharper-angularjs.7.1", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "resharper-angularjs.8.0", "resharper-angularjs\resharper-angularjs.8.0.csproj", "{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "7.1", "7.1", "{670EE92D-2D29-4CAE-A171-9273DFBB3635}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "8.0", "8.0", "{1487BDE4-245C-49A0-B292-E90D0B2AD3B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests.8.0", "tests\tests.8.0.csproj", "{506568A3-0598-4604-95A4-B644356F247A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,8 +25,17 @@ Global
 		{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{506568A3-0598-4604-95A4-B644356F247A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{506568A3-0598-4604-95A4-B644356F247A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{506568A3-0598-4604-95A4-B644356F247A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{506568A3-0598-4604-95A4-B644356F247A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{ABEF4568-7276-41FD-96A7-96138A689765} = {670EE92D-2D29-4CAE-A171-9273DFBB3635}
+		{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99} = {1487BDE4-245C-49A0-B292-E90D0B2AD3B7}
+		{506568A3-0598-4604-95A4-B644356F247A} = {1487BDE4-245C-49A0-B292-E90D0B2AD3B7}
 	EndGlobalSection
 EndGlobal

--- a/src/tests/Placeholder.cs
+++ b/src/tests/Placeholder.cs
@@ -1,0 +1,30 @@
+﻿#region license
+// Copyright 2013 JetBrains s.r.o.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using NUnit.Framework;
+
+namespace JetBrains.ReSharper.Plugins.AngularJS.Tests
+{
+  [TestFixture]
+  public class Placeholder
+  {
+    [Test]
+    public void PlaceholderTest()
+    {
+      
+    }
+  }
+}

--- a/src/tests/Properties/AssemblyInfo.cs
+++ b/src/tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,44 @@
+using JetBrains.Application;
+using JetBrains.ReSharper.Plugins.AngularJS;
+using JetBrains.Threading;
+using System.Reflection;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+/// <summary>
+/// Test environment. Must be in the global namespace.
+/// </summary>
+[SetUpFixture]
+// ReSharper disable once CheckNamespace
+public class TestEnvironmentAssembly : ReSharperTestEnvironmentAssembly
+{
+  /// <summary>
+  /// Gets the assemblies to load into test environment.
+  /// Should include all assemblies which contain components.
+  /// </summary>
+  private static IEnumerable<Assembly> GetAssembliesToLoad()
+  {
+    // Test assembly
+    yield return Assembly.GetExecutingAssembly();
+
+    yield return typeof(AngularJsHtmlElementsProvider).Assembly;
+  }
+
+  public override void SetUp()
+  {
+    base.SetUp();
+    ReentrancyGuard.Current.Execute(
+      "LoadAssemblies",
+      () => Shell.Instance.GetComponent<AssemblyManager>().LoadAssemblies(
+        GetType().Name, GetAssembliesToLoad()));
+  }
+
+  public override void TearDown()
+  {
+    ReentrancyGuard.Current.Execute(
+      "UnloadAssemblies",
+      () => Shell.Instance.GetComponent<AssemblyManager>().UnloadAssemblies(
+        GetType().Name, GetAssembliesToLoad()));
+    base.TearDown();
+  }
+}

--- a/src/tests/ReadMe.txt
+++ b/src/tests/ReadMe.txt
@@ -1,0 +1,7 @@
+You have just generated an empty ReSharper plug-in test project.
+
+To add additional tests to your project, use the Add|New Item... menu.
+
+To add test data to your project, open or create a \test\data folder inside
+the solution folder. Then, in each of the tests you create, be sure to override
+the RelativeTestDataPath property to correctly point ReSharper to your tests.

--- a/src/tests/tests.8.0.csproj
+++ b/src/tests/tests.8.0.csproj
@@ -5,11 +5,11 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{F11FEAE0-0B1B-4D41-BFAB-A3685513EE99}</ProjectGuid>
+    <ProjectGuid>{506568A3-0598-4604-95A4-B644356F247A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>JetBrains.ReSharper.Plugins.AngularJS</RootNamespace>
-    <AssemblyName>JetBrains.ReSharper.Plugins.AngularJS.8.0</AssemblyName>
+    <RootNamespace>JetBrains.ReSharper.Plugins.AngularJS.Tests</RootNamespace>
+    <AssemblyName>JetBrains.ReSharper.Plugins.AngularJS.Tests.8.0</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;JET_MODE_ASSERT,RESHARPER_8</DefineConstants>
+    <DefineConstants>JET_MODE_ASSERT;DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;RESHARPER_8</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -44,27 +44,21 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AngularJsHtmlElementDescriptionProvider.cs" />
-    <Compile Include="AngularJsHtmlElementsProvider.cs" />
+    <Compile Include="Placeholder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TemplateHacks\DelegatingScopePoint.cs" />
-    <Compile Include="TemplateHacks\JsAllowedPrefixes.cs" />
-    <Compile Include="TemplateHacks\NonDefaultPrefixJavaScriptScopeProvider.cs" />
-    <Compile Include="TemplateHacks\TemplateWithNonDefaultPrefixesItemsProvider.cs" />
-    <Compile Include="TemplateHacks\TypeScriptFilePrefixScopeProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\install\resharper-angularjs.nuspec">
-      <Link>resharper-angularjs.nuspec</Link>
-    </None>
-    <None Include="angularjs-templates.dotSettings" />
+    <Content Include="ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\HtmlElements.xml" />
+    <ProjectReference Include="..\resharper-angularjs\resharper-angularjs.8.0.csproj">
+      <Project>{f11feae0-0b1b-4d41-bfab-a3685513ee99}</Project>
+      <Name>resharper-angularjs.8.0</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <ReSharperSdkTargets Condition=" '$(ReSharperSdkTargets)' == '' ">$(MSBuildExtensionsPath)\JetBrains\ReSharper.SDK\v8.0</ReSharperSdkTargets>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ReSharperSdkTargets)\Plugin.Targets" />
+  <Import Project="$(ReSharperSdkTargets)\Plugin.Tests.Targets" />
 </Project>


### PR DESCRIPTION
This PR is intended to hold the changes required to get ReSharper to understand controllers in angular.

Specifically:
- Code completion in `ng-controller` and `data-ng-controller` attributes
- Ctrl-click/goto definition navigation from the attribute value to the JS declaration of the controller
- Renaming the controller should rename the attribute value
- Find usages on the controller should highlight the attribute value, and vice versa

Steps to get this done (do not merge until done):
- [x] Add a test project
- [ ] Create an `ICache` implementation to parse all JS files in the solution and find controller declarations. See ReSharper's `JavascriptTestCache` implementation.
- [ ] Write tests to validate the cache implementation
- [ ] Create a reference provider that builds references on `ng-controller` and `data-ng-controller` attribute value tree elements. When resolving the reference, it looks up the controller in the cache. The reference allows navigation, find usages and renaming to work, and highlights when references can't be found
- [ ] Write tests for the reference provider
- [ ] Extend the reference provider to give code completion by implementing `ICompletableReferenceProvider`

The PsiPlugin sample in the SDK provides an implementation of `ICache`. Also, ReSharper's `JavascriptTestCache` class is a good example (dotPeek is your friend) - it parses JavaScript files to locate and cache tests.

The [xunitcontrib project](https://xunitcontrib.codeplex.com/SourceControl/latest#resharper/src/xunitcontrib.runner.resharper.provider/PropertyData/PropertyDataReferenceProviderFactory.cs) has an example of a reference provider to give code completion and navigation/find usages/renaming in a string literal in an attribute.

Note that this should support 7.1 as well as 8.0
